### PR TITLE
fixed updating audio bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mui-audio-player",
-  "version": "1.0.0",
+  "name": "mui-audio-player-plus",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mui-audio-player",
-      "version": "1.0.0",
+      "name": "mui-audio-player-plus",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@mui/icons-material": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "watch": "tsc --watch",
     "build": "tsc",
     "dev": "npm run watch & npm run start:example",
-    "start:example": "cd example && npm start"
+    "start:example": "cd example && npm start",
+    "postinstall": "tsc --outDir ./build"
   },
   "repository": {
     "type": "git",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,6 +69,7 @@ const MuiAudioPlayer = ({
   const [position, setPosition] = useState(0);
   const [currentTime, setCurrentTime] = useState("00:00");
   const [endTime, setEndTime] = useState("");
+  const [audioElement, setAudioElement] = useState<HTMLAudioElement | null>(null);
   const wavesurferRef = React.useRef<WaveSurferRef>();
 
   const handleMount: WaveSurferProps[`onMount`] = React.useCallback(
@@ -108,8 +109,9 @@ const MuiAudioPlayer = ({
     [src]
   );
 
-  const audioElement = useMemo(() => {
-    if (display != "timeline") return null;
+  useEffect(() => {
+    if (display != "timeline") return;
+    audioElement?.pause();
     const audio = new Audio(src);
     audio.addEventListener("playing", () => setPlaying(true));
     ["pause", "ended"].forEach((e) =>
@@ -125,7 +127,7 @@ const MuiAudioPlayer = ({
     });
 
     audio.addEventListener("error", (e) => console.error(e));
-    return audio;
+    setAudioElement(audio);
   }, [src, display]);
 
   const handlePlay = () => {
@@ -164,7 +166,7 @@ const MuiAudioPlayer = ({
           )}
         </IconButton>
       ),
-    [size, playPauseIconButtonProps, playing, loading]
+    [size, playPauseIconButtonProps, playing, loading, handlePlay]
   );
 
   if (!src) return null;


### PR DESCRIPTION
I'm using this package, and I noticed a bug:
I have a form that can **Add**, **Edit** or **Show** the person's voice.
In edit, if I want to upload new audio to the form it is expected to play the new one; but it keeps on playing the previous audio. After the whole pre-audio complete playing, hitting the play button will play the new audio.

I recognize that the `audio` in `handlePlay` function has the pre-audio URL while I changed the audio. And once the function fires (after whole pre-audio played OR hit the pause/play button once), the `audio` inside `handlePlay` will change.

### what I changed
- Added the `handlePlay` to the `PlayPauseButton` callback dependencies.
- Changed `useMemo` to `useEffect` and take the `audioElement` to the states; SO I could stop the pre-audio playing while changing to the new audio.

Hope my description helps understanding the bug.
I really appreciate if you accept this pull request ASAP, cause I need it.